### PR TITLE
🎨 Different color for inactive files in the project tree

### DIFF
--- a/src/main/resources/gruvbox_theme.theme.json
+++ b/src/main/resources/gruvbox_theme.theme.json
@@ -38,11 +38,11 @@
       "endBorderColor": "#504945",
 
       "default": {
-        "foreground": "#504945",
-        "startBackground": "#83a598",
-        "endBackground": "#83a598",
-        "startBorderColor": "#83a598",
-        "endBorderColor": "#83a598",
+        "foreground": "#fbf1c7",
+        "startBackground": "#32302F",
+        "endBackground": "#32302F",
+        "startBorderColor": "#4F4945",
+        "endBorderColor": "#4F4945",
         "focusedBorderColor": "#282828"
       }
     },

--- a/src/main/resources/gruvbox_theme.theme.json
+++ b/src/main/resources/gruvbox_theme.theme.json
@@ -11,7 +11,7 @@
       "infoForeground": "#ebdbb2",
 
       "lightSelectionBackground": "#3c3836",
-      "selectionBackground": "#3c3836",
+      "selectionBackground": "#4F4945",
       "selectionForeground": "#fbf1c7",
       "selectionInactiveBackground": "#3c3836",
       "selectionBackgroundInactive": "#3c3836",


### PR DESCRIPTION
This fixes https://github.com/Vincent-P/gruvbox-intellij-theme/issues/2

The final result:
![screencast 2019-05-08 00-03-42](https://user-images.githubusercontent.com/1331435/57336059-eff3bb80-7124-11e9-9129-d9409f4c04eb.gif)

Also, I've changed to a more subtle colors the default button:
![image](https://user-images.githubusercontent.com/1331435/57336102-1154a780-7125-11e9-873d-66ddba77c1a2.png)
If you don't like it I can revert that :)