### PR TITLE
Fix issue with cursor in pycharm console (#29) 

### DIFF
--- a/src/main/resources/gruvbox_dark_hard.xml
+++ b/src/main/resources/gruvbox_dark_hard.xml
@@ -146,7 +146,9 @@
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
@@ -165,7 +167,9 @@
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>

--- a/src/main/resources/gruvbox_dark_medium.xml
+++ b/src/main/resources/gruvbox_dark_medium.xml
@@ -146,7 +146,9 @@
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
@@ -165,7 +167,9 @@
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>

--- a/src/main/resources/gruvbox_dark_soft.xml
+++ b/src/main/resources/gruvbox_dark_soft.xml
@@ -146,7 +146,9 @@
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
@@ -165,7 +167,9 @@
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="ebdbb2" />
+      </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>

--- a/src/main/resources/gruvbox_light_hard.xml
+++ b/src/main/resources/gruvbox_light_hard.xml
@@ -144,7 +144,9 @@
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="3c3836" />
+      </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
@@ -163,7 +165,9 @@
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="3c3836" />
+      </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>

--- a/src/main/resources/gruvbox_light_medium.xml
+++ b/src/main/resources/gruvbox_light_medium.xml
@@ -144,7 +144,9 @@
       </value>
     </option>
     <option name="CONSOLE_NORMAL_OUTPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="3c3836" />
+      </value>
     </option>
     <option name="CONSOLE_RED_BRIGHT_OUTPUT">
       <value>
@@ -163,7 +165,9 @@
       </value>
     </option>
     <option name="CONSOLE_USER_INPUT">
-      <value />
+      <value>
+        <option name="FOREGROUND" value="3c3836" />
+      </value>
     </option>
     <option name="CONSOLE_WHITE_OUTPUT">
       <value>


### PR DESCRIPTION
This PR provides a fix for the behavior described in #29. 

In comparing the plugin's theme definitions with those of a handful of other plugins (e.g. Nord, Material, and Solarized), I noticed that ours don't specify a concrete value for CONSOLE_USER_INPUT, as shown here:

```
<option name="CONSOLE_USER_INPUT">
  <value />
</option>
```

When the value is specified, as below, the Pycharm's console cursor appears in the correct place. So it seems like Pycharm takes issue with the definition above. Shame it doesn't issue a warning or anything.

```
<option name="CONSOLE_USER_INPUT">
  <value>
    <option name="FOREGROUND" value="ebdbb2" />
  </value>
</option>
```

This isn't the only instance of `<value />` in the theme definitions. I've also provided a concrete specification for CONSOLE_NORMAL_OUTPUT. The rest I've left as is, since there are no indications that they are causing problems.