### PR TITLE
Added support for Rider 2020.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ publishPlugin {
 }
 
 group 'com.vincentp'
-version '0.4.2'
+version '0.4.3'
 
 sourceCompatibility = 1.8
 
@@ -27,6 +27,10 @@ intellij {
 
 patchPluginXml {
     changeNotes """
+    <h2>0.4.3</h2>
+    <ul>
+        <li>Update to work with 2020.3</li>
+    </ul>
     <h2>0.4.2</h2>
     <ul>
         <li>Fix PyCharm Python Console prompt. (thanks @lemontheme!) </li>
@@ -79,5 +83,5 @@ patchPluginXml {
       """
 
     sinceBuild '183.0'
-    untilBuild '202.*'
+    untilBuild '203.*'
 }


### PR DESCRIPTION
This PR adds support for installing the theme in the Rider 2020.3 series by updating the untilBuild property.