### PR TITLE
update max supported version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.5.3
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#intellij-platform-based-products-of-recent-ide-versions
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 191.0
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
With the new UI of intellij the plugin is not supported so i had to change the version manually.

This was tested on EAP Intellij.

Some info about the build:

`Runtime version: 17.0.3+7-b463.3 aarch64`

`Build #IU-222.2680.4, built on May 25, 2022`